### PR TITLE
Add local + CI for source-build build infra

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,6 +42,7 @@ stages:
       enablePublishTestResults: true
       enablePublishBuildAssets: true
       enablePublishUsingPipelines: ${{ variables._PublishUsingPipelines }}
+      enableSourceBuild: true
       enableTelemetry: true
       helixRepo: dotnet/xdt
       jobs:

--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -1,0 +1,8 @@
+<Project>
+
+  <PropertyGroup>
+    <GitHubRepositoryName>xdt</GitHubRepositoryName>
+    <SourceBuildManagedOnly>true</SourceBuildManagedOnly>
+  </PropertyGroup>
+
+</Project>

--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -1,0 +1,5 @@
+<UsageData>
+  <IgnorePatterns>
+    <UsagePattern IdentityGlob="*/*" />
+  </IgnorePatterns>
+</UsageData>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -4,6 +4,7 @@
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="6.0.0-beta.21125.5">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>15246f4af00a1cb2e580783d32ec2937b1878a64</Sha>
+      <SourceBuild RepoName="arcade" ManagedOnly="true"/>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>


### PR DESCRIPTION
This enables 'source-build', which makes it easier to build the entire shipping .NET SDK from source.

This is the first step of arcade-powered-source-build:
https://github.com/dotnet/source-build/blob/master/Documentation/planning/arcade-powered-source-build/README.md

See https://github.com/dotnet/sourcelink/pull/692 for a similar PR, that this is based on.

cc @dagood 