### PR TITLE
Update tag references to dotnet-buildtools/prereqs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,7 +31,7 @@ variables:
 resources:
   containers:
   - container: LinuxContainer
-    image: microsoft/dotnet-buildtools-prereqs:ubuntu-14.04-cross-0cd4667-20170319080304
+    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-14.04-cross-0cd4667-20170319080304
 
 stages:
 - stage: build


### PR DESCRIPTION
Updating Docker image tag references that are obsolete and replaced by references to mcr.microsoft.com/dotnet-buildtools/prereqs. See dotnet/dotnet-docker#2848.