### PR TITLE
Build Microsoft.Web.XmlTransform for netstandard2.0 to support NuGet during source build.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -117,7 +117,7 @@ stages:
 
       - job: OSX
         pool:
-          name: Hosted macOS
+          vmImage: 'macOS-1015'
         strategy:
           matrix:
             debug_configuration:
@@ -136,7 +136,7 @@ stages:
           
       - job: Linux
         pool:
-          name: Hosted Ubuntu 1604
+          vmImage: 'ubuntu-20.04'
         container: LinuxContainer
         strategy:
           matrix:

--- a/src/Microsoft.Web.XmlTransform/Microsoft.Web.XmlTransform.csproj
+++ b/src/Microsoft.Web.XmlTransform/Microsoft.Web.XmlTransform.csproj
@@ -3,7 +3,7 @@
   <Import Project="$(RepositoryEngineeringDir)\Package.props" />
   
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <IsPackable>true</IsPackable>
     <IsShipping>false</IsShipping>


### PR DESCRIPTION
The source build team is making an effort to backport all of our patches. This change adds an additional netstandard2.0 TFM for Microsoft.Web.XmlTransform so that NuGet can use it in source build.