### PR TITLE
update docker tag to latest schema

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,7 +31,7 @@ variables:
 resources:
   containers:
   - container: LinuxContainer
-    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-14.04-cross-0cd4667-20170319080304
+    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-14.04-cross-latest
 
 stages:
 - stage: build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,7 +31,7 @@ variables:
 resources:
   containers:
   - container: LinuxContainer
-    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-14.04-cross-latest
+    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-latest
 
 stages:
 - stage: build


### PR DESCRIPTION
As a part of https://github.com/dotnet/arcade/issues/10123, we are moving all docker containers to the "latest" tagging schema