### PR TITLE
Remove 'latest' from the docker tags

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,7 +31,7 @@ variables:
 resources:
   containers:
   - container: LinuxContainer
-    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-latest
+    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross
 
 stages:
 - stage: build


### PR DESCRIPTION
It was decided that we will remove the "-latest" part from our docker tags 