### PR TITLE
add dep versions to versions.props

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -8,7 +8,7 @@
     </Dependency>
     <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="8.0.0-alpha.1.22517.1">
       <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
-      <Sha>2288850ad99cac4de5968ed609144bfdc81567ce</Sha>
+      <Sha>ec4fdcded4dd6152c9c05291759c1a97b24f52e5</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.SourceLink.GitHub" Version="1.2.0-beta-22503-03" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -7,4 +7,9 @@
     <VersionPrefix>7.0.0</VersionPrefix>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
   </PropertyGroup>
+  <!--Package versions-->
+  <PropertyGroup>
+    <MicrosoftSourceBuildIntermediatesourcebuildreferencepackagesPackageVersion>8.0.0-alpha.1.22517.1</MicrosoftSourceBuildIntermediatesourcebuildreferencepackagesPackageVersion>
+    <MicrosoftSourceLinkGitHubPackageVersion>1.2.0-beta-22503-03</MicrosoftSourceLinkGitHubPackageVersion>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Resolves https://github.com/dotnet/xdt/issues/461 and https://github.com/dotnet/xdt/pull/470#pullrequestreview-1147897685

@vijayrkn apologize for another ping, this PR is finishing up the work forgotten in https://github.com/dotnet/xdt/pull/470, primarily adding the dep versions to `Versions.props`

Also, added a subscription for the newly introduced SBRP dependency:
```
https://github.com/dotnet/source-build-reference-packages (.NET Eng - Latest) ==> 'https://github.com/dotnet/xdt' ('main')
  - Id: ***
  - Update Frequency: EveryWeek
  - Enabled: True
  - Batchable: False
  - PR Failure Notification tags:
  - Merge Policies:
    Standard
``` 