### PR TITLE
Enable Binskim scan in CI builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -165,6 +165,8 @@ stages:
         enable: true
         continueOnError: false
         params: ' -SourceToolsList @("policheck","credscan")
+        -ArtifactToolsList @("binskim")
+        -BinskimAdditionalRunConfigParams @("IgnorePdbLoadError < True","Recurse < True")
         -TsaInstanceURL $(_TsaInstanceURL)
         -TsaProjectName $(_TsaProjectName)
         -TsaNotificationEmail $(_TsaNotificationEmail)


### PR DESCRIPTION
Enabling **BinSkim** scan over build artifacts in CI based on company requirements.

We are required to run SDL tools on official builds and implement automated bug filling for the tools output. Currently we are running SDL checks over the source code in the nightly builds, inline in the builds for some of the product repos and in the .NET staging pipeline, but to be compliant we need to also run BinSkim over the produced artifacts.

This PRs is enabling **BinSkim** checks in the `Run SDL tool job` of [Xdt-ci-official](https://dev.azure.com/dnceng/internal/_build?definitionId=421).

More information is in the [Automate BinSkim runs over official builds issue](https://github.com/dotnet/arcade-services/issues/2647)  