### PR TITLE
Update Microsoft.Web.XmlTransform.Tests.csproj

### DIFF
--- a/tests/Microsoft.Web.XmlTransform.Tests/Microsoft.Web.XmlTransform.Tests.csproj
+++ b/tests/Microsoft.Web.XmlTransform.Tests/Microsoft.Web.XmlTransform.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
-    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The exclude is already the default behavior for test projects. Clean-up only.