### PR TITLE
Fork pipeline definition

### DIFF
--- a/azure-pipelines-pr.yml
+++ b/azure-pipelines-pr.yml
@@ -1,0 +1,112 @@
+trigger:
+  batch: true
+  branches:
+    include:
+    - main
+    - release/*.*
+
+pr:
+  branches:
+    include:
+    - main
+    - release/*.*
+
+variables:
+  # Cannot use key:value syntax in root defined variables
+  - name: _TeamName
+    value: DotNetCore
+  - name: _PublishUsingPipelines
+    value: true
+  - name: _DotNetArtifactsCategory
+    value: .NETCore
+  - name: Codeql.Enabled
+    value: true
+    
+resources:
+  containers:
+  - container: LinuxContainer
+    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross
+
+stages:
+- stage: build
+  displayName: Build
+  jobs:
+  - template: /eng/common/templates/jobs/jobs.yml
+    parameters:
+      enableMicrobuild: true
+      enablePublishBuildArtifacts: true
+      enablePublishTestResults: true
+      enablePublishBuildAssets: true
+      enablePublishUsingPipelines: ${{ variables._PublishUsingPipelines }}
+      enableSourceBuild: true
+      enableTelemetry: true
+      helixRepo: dotnet/xdt
+      jobs:
+      - job: Windows_NT
+        pool:
+          vmImage: windows-2019
+
+        variables:
+        - _Script: eng\common\cibuild.cmd
+        - _ValidateSdkArgs: ''
+        - _InternalBuildArgs: ''
+
+        strategy:
+          matrix:
+            Build_Debug:
+              _BuildConfig: Debug
+              _PublishType: none
+              _SignType: test
+            Build_Release:
+              _BuildConfig: Release
+              _PublishType: none
+              _SignType: test
+        steps:
+        - checkout: self
+          clean: true
+        # Use utility script to run script command dependent on agent OS.
+        - script: $(_Script)
+            -configuration $(_BuildConfig) 
+            -prepareMachine
+            $(_InternalBuildArgs)
+            $(_ValidateSdkArgs)
+          displayName: Windows Build / Publish
+
+      - job: OSX
+        pool:
+          vmImage: 'macOS-11'
+        strategy:
+          matrix:
+            debug_configuration:
+              _BuildConfig: Debug
+            release_configuration:
+              _BuildConfig: Release
+        steps:
+        - checkout: self
+          clean: true
+        - script: eng/common/cibuild.sh
+            --configuration $(_BuildConfig)
+            --prepareMachine
+          name: Build
+          displayName: Build
+          condition: succeeded()
+          
+      - job: Linux
+        pool:
+          vmImage: 'ubuntu-20.04'
+        container: LinuxContainer
+        strategy:
+          matrix:
+            debug_configuration:
+              _BuildConfig: Debug
+            release_configuration:
+              _BuildConfig: Release
+        steps:
+        - checkout: self
+          clean: true
+        - script: eng/common/cibuild.sh
+            --configuration $(_BuildConfig)
+            --prepareMachine
+          name: Build
+          displayName: Build
+          condition: succeeded()


### PR DESCRIPTION
This is step 1 of migrating the pipelines to the 1ES templates. This just forks the pipeline definition we use for PRs off from the one we use internally for CI. The new PR-only definition does not need to be migrated.

Note that the new definition won't run during this PR's validation step - I'll switch over the configured validation once this is in main.