### PR TITLE
Bump macos image in azure-pipelines-pr.yml

### DIFF
--- a/azure-pipelines-pr.yml
+++ b/azure-pipelines-pr.yml
@@ -74,7 +74,7 @@ stages:
 
       - job: OSX
         pool:
-          vmImage: 'macOS-11'
+          vmImage: 'macOS-12'
         strategy:
           matrix:
             debug_configuration:


### PR DESCRIPTION
AzDO will remove macos-11 later this month.