### PR TITLE
Mark Microsoft.Web.XmlTransform assembly as shipping

### DIFF
--- a/src/Microsoft.Web.XmlTransform/Microsoft.Web.XmlTransform.csproj
+++ b/src/Microsoft.Web.XmlTransform/Microsoft.Web.XmlTransform.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(NetCurrent);netstandard2.0</TargetFrameworks>
     <PackageId>Microsoft.Web.Xdt</PackageId>
     <IsPackable>true</IsPackable>
-    <IsShipping>false</IsShipping>
+    <IsShippingPackage>false</IsShippingPackage>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Microsoft.Web.XmlTransform.dll ships inside the dotnet/sdk but is marked as non-shipping. Change this to only mark the package as non-shipping and not the assembly.