### PR TITLE
Remove explicitly setting tsaoptions.json path

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,7 +39,6 @@ extends:
         enabled: true
       tsa:
         enabled: true
-        configFile: '$(Build.SourcesDirectory)\.config\tsaoptions.json'
     customBuildTags:
     - ES365AIMigrationTooling
     stages:


### PR DESCRIPTION
It's the default path and the backslash causes TSA to fail to find the file on Linux